### PR TITLE
ci: adapt tag pattern for packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*v*.*.*"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
release-please is tagging automatically the branch with `repoName-vx.x.x` 
I don't know yet if it uses capital letters. We will adapt later