### PR TITLE
fix(inferences): rely on final status rather than intermediates one to display the result

### DIFF
--- a/Scenario/Editor/PromptWindow/PromptWindow.cs
+++ b/Scenario/Editor/PromptWindow/PromptWindow.cs
@@ -314,7 +314,7 @@ public class PromptWindow : EditorWindow
         {
             InferenceStatusRoot inferenceStatusRoot = JsonConvert.DeserializeObject<InferenceStatusRoot>(response.Content);
 
-            if (inferenceStatusRoot.inference.status == "in-progress")
+            if (inferenceStatusRoot.inference.status == "in-progress" || inferenceStatusRoot.inference.status == "queued")
             {
                 Debug.Log("Commission in process, please wait..");
                 EditorCoroutineUtility.StopCoroutine(inferenceStatusCoroutine);

--- a/Scenario/Editor/PromptWindow/PromptWindow.cs
+++ b/Scenario/Editor/PromptWindow/PromptWindow.cs
@@ -314,7 +314,7 @@ public class PromptWindow : EditorWindow
         {
             InferenceStatusRoot inferenceStatusRoot = JsonConvert.DeserializeObject<InferenceStatusRoot>(response.Content);
 
-            if (inferenceStatusRoot.inference.status == "in-progress" || inferenceStatusRoot.inference.status == "queued")
+            if (inferenceStatusRoot.inference.status != "succeeded" && inferenceStatusRoot.inference.status != "failed" )
             {
                 Debug.Log("Commission in process, please wait..");
                 EditorCoroutineUtility.StopCoroutine(inferenceStatusCoroutine);


### PR DESCRIPTION
Adding a new status to inferences before `in-progress` is triggering an issue and you do not see your results.
We now will rely on final status of the inference before displaying the result 