### PR TITLE
fix!: refresh images window

### DIFF
--- a/package/Editor/Images/Images.cs
+++ b/package/Editor/Images/Images.cs
@@ -24,21 +24,25 @@ namespace Scenario.Editor
         public static void ShowWindow()
         {
             if (isVisible)
-                return;
+            {
+                GetInferencesData();
+            }
+            else
+            {
+                lastPageToken = string.Empty;
+                imageDataList.Clear();
+                GetInferencesData();
 
-            lastPageToken = string.Empty;
-            imageDataList.Clear();
-            GetInferencesData();
-
-            var images = (Images)GetWindow(typeof(Images));
-            ImagesUI.Init(images);
+                var images = (Images)GetWindow(typeof(Images));
+                ImagesUI.Init(images);
+            }
         }
 
         private void OnGUI()
         {
             ImagesUI.OnGUI(this.position);
         }
-    
+
         private void OnDestroy()
         {
             ImagesUI.OnClose();

--- a/package/Editor/Images/Images.cs
+++ b/package/Editor/Images/Images.cs
@@ -23,19 +23,15 @@ namespace Scenario.Editor
         [MenuItem("Window/Scenario/Images")]
         public static void ShowWindow()
         {
-            if (isVisible)
-            {
-                GetInferencesData();
-            }
-            else
+            if (!isVisible)
             {
                 lastPageToken = string.Empty;
                 imageDataList.Clear();
-                GetInferencesData();
-
-                var images = (Images)GetWindow(typeof(Images));
-                ImagesUI.Init(images);
             }
+            GetInferencesData();
+
+            var images = (Images)GetWindow(typeof(Images));
+            ImagesUI.Init(images);
         }
 
         private void OnGUI()

--- a/package/Editor/Images/Images.cs
+++ b/package/Editor/Images/Images.cs
@@ -43,6 +43,11 @@ namespace Scenario.Editor
             ImagesUI.OnGUI(this.position);
         }
 
+        private void OnEnable()
+        {
+            ShowWindow();
+        }
+
         private void OnDestroy()
         {
             ImagesUI.OnClose();

--- a/package/Editor/_Services/PromptFetcher.cs
+++ b/package/Editor/_Services/PromptFetcher.cs
@@ -90,6 +90,8 @@ namespace Scenario.Editor
                             inferenceStatusRoot.inference.createdAt,
                             img.Seed);
                     }
+
+                    Images.ShowWindow();
                 }
             });
         }


### PR DESCRIPTION
If the user has no image on his account and tries to generate for the first time. The first images generated will be displayed now.
Then, when you close Unity and reopen it, or a compilation occurs with the images open, the images are still displayed.

-closes: #146 
-closes: #144 