### PR TITLE
fix: 125 control net options should have the same naming as on the webapp

### DIFF
--- a/package/Editor/Models/Models.cs
+++ b/package/Editor/Models/Models.cs
@@ -213,7 +213,6 @@ namespace Scenario.Editor
         {
             if (!isProcessing)
             {
-
                 while (true)
                 {
                     isProcessing = true;

--- a/package/Editor/Models/ModelsUI.cs
+++ b/package/Editor/Models/ModelsUI.cs
@@ -93,10 +93,10 @@ namespace Scenario.Editor
                 {
                     continue;
                 }
-            
-                pageModels.Add(models[i]);
+
+                pageModels.Add(models[i]); 
             }
-            numberPages = (models.Count / maxModelsPerPage) +1;
+            numberPages = (models.Count / maxModelsPerPage) + 1;
 
             if (currentPage < numberPages)
             {

--- a/package/Editor/Models/ModelsUI.cs
+++ b/package/Editor/Models/ModelsUI.cs
@@ -168,6 +168,8 @@ namespace Scenario.Editor
                         if (globalIndex >= 0 && globalIndex < models.Count)
                         {
                             DataCache.instance.SelectedModelId = models[globalIndex].id;
+                            DataCache.instance.SelectedModelType = models[globalIndex].type;
+                            
                             EditorPrefs.SetString("SelectedModelName", name);
                         }
 

--- a/package/Editor/PromptWindow/PromptWindow.cs
+++ b/package/Editor/PromptWindow/PromptWindow.cs
@@ -205,7 +205,7 @@ namespace Scenario.Editor
 
             if (promptWindowUI.selectedOptionIndex > 0)
             {
-                string optionName = promptWindowUI.dropdownOptions[promptWindowUI.selectedOptionIndex - 1];
+                string optionName = promptWindowUI.correspondingOptionsValue[promptWindowUI.selectedOptionIndex - 1];
                 if (!modalitySettings.ContainsKey(optionName))
                 { 
                     modalitySettings.Add(optionName, $"{promptWindowUI.sliderValue:0.00}");

--- a/package/Editor/PromptWindow/PromptWindowUI.cs
+++ b/package/Editor/PromptWindow/PromptWindowUI.cs
@@ -15,15 +15,23 @@ namespace Scenario.Editor
         public readonly string[] dropdownOptions =
         {
             "",
-            "canny",
-            "pose",
-            "depth",
-            "lines",
-            "seg",
-            "scribble",
-            "lineart",
-            "normal-map",
-            "shuffle"
+            "Character",
+            "Landscape",
+            "Structure",
+            "Pose",
+            "Depth",
+            "Segmentation",
+            "Illusion"
+        };
+
+        public readonly string[] dropdownOptionsSD15 =
+        {
+            "City",
+            "Interior",
+            "Edges",
+            "Scribble",
+            "Normal Map",
+            "Line Art"
         };
 
         internal readonly string[] schedulerOptions = new string[] // Scheduler options extracted from your HTML

--- a/package/Editor/PromptWindow/PromptWindowUI.cs
+++ b/package/Editor/PromptWindow/PromptWindowUI.cs
@@ -12,6 +12,9 @@ namespace Scenario.Editor
     
         internal static Texture2D imageUpload;
 
+        /// <summary>
+        /// First dropdown options according to SDXL models
+        /// </summary>
         public readonly string[] dropdownOptions =
         {
             "",
@@ -24,6 +27,9 @@ namespace Scenario.Editor
             "Illusion"
         };
 
+        /// <summary>
+        /// Seconds dropdown options according to SD 1.5 models
+        /// </summary>
         public readonly string[] dropdownOptionsSD15 =
         {
             "City",
@@ -32,6 +38,27 @@ namespace Scenario.Editor
             "Scribble",
             "Normal Map",
             "Line Art"
+        };
+
+        /// <summary>
+        /// Translation to api calling modalities options, treat previous values in the exact same order.
+        /// </summary>
+        public readonly string[] correspondingOptionsValue =
+        {
+            "",
+            "character",
+            "landscape",
+            "canny",
+            "pose",
+            "depth",
+            "seg",
+            "illusion",
+            "city",
+            "interior",
+            "lines",
+            "scribble",
+            "normal-map",
+            "lineart"
         };
 
         internal readonly string[] schedulerOptions = new string[] // Scheduler options extracted from your HTML

--- a/package/Editor/PromptWindow/Views/ControlNetView.cs
+++ b/package/Editor/PromptWindow/Views/ControlNetView.cs
@@ -34,6 +34,35 @@ namespace Scenario.Editor
                 GUILayout.Label("Model 1", EditorStyles.label);
 
                 List<string> availableOptions1 = new List<string> { "None" };
+
+                
+                if (!string.IsNullOrEmpty(DataCache.instance.SelectedModelType))
+                {
+                    switch (DataCache.instance.SelectedModelType)
+                    {
+                        case "sd-xl-composition":
+                            availableOptions1.AddRange(dropdownOptions);
+                            break;
+
+                        case "sd-xl-lora":
+                            availableOptions1.AddRange(dropdownOptions);
+                            break;
+
+                        case "sd-xl":
+                            availableOptions1.AddRange(dropdownOptions);
+                            break;
+
+                        case "sd-1_5":
+                            availableOptions1.AddRange(dropdownOptions);
+                            availableOptions1.AddRange(dropdownOptionsSD15);
+                            break;
+
+                        default: 
+                            break;
+
+                    }
+                }
+
                 availableOptions1.AddRange(dropdownOptions);
                 selectedOption1Index = EditorGUILayout.Popup(selectedOption1Index, availableOptions1.ToArray());
 

--- a/package/Editor/PromptWindow/Views/ControlNetView.cs
+++ b/package/Editor/PromptWindow/Views/ControlNetView.cs
@@ -33,7 +33,7 @@ namespace Scenario.Editor
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Modality :", EditorStyles.label);
 
-                List<string> availableOptions1 = new List<string> { "None" };
+                List<string> availableOptions = new List<string> { "None" };
 
                 
                 if (!string.IsNullOrEmpty(DataCache.instance.SelectedModelType))
@@ -41,20 +41,20 @@ namespace Scenario.Editor
                     switch (DataCache.instance.SelectedModelType)
                     {
                         case "sd-xl-composition":
-                            availableOptions1.AddRange(dropdownOptions);
+                            availableOptions.AddRange(dropdownOptions);
                             break;
 
                         case "sd-xl-lora":
-                            availableOptions1.AddRange(dropdownOptions);
+                            availableOptions.AddRange(dropdownOptions);
                             break;
 
                         case "sd-xl":
-                            availableOptions1.AddRange(dropdownOptions);
+                            availableOptions.AddRange(dropdownOptions);
                             break;
 
                         case "sd-1_5":
-                            availableOptions1.AddRange(dropdownOptions);
-                            availableOptions1.AddRange(dropdownOptionsSD15);
+                            availableOptions.AddRange(dropdownOptions);
+                            availableOptions.AddRange(dropdownOptionsSD15);
                             break;
 
                         default: 
@@ -63,8 +63,8 @@ namespace Scenario.Editor
                     }
                 }
 
-                availableOptions1.AddRange(dropdownOptions);
-                selectedOptionIndex = EditorGUILayout.Popup(selectedOptionIndex, availableOptions1.ToArray());
+                //availableOptions.AddRange(dropdownOptions);
+                selectedOptionIndex = EditorGUILayout.Popup(selectedOptionIndex, availableOptions.ToArray());
 
                 if (selectedOptionIndex > 0)
                 { 

--- a/package/Editor/_Services/DataCache.cs
+++ b/package/Editor/_Services/DataCache.cs
@@ -12,6 +12,10 @@ namespace Scenario.Editor
     /// </summary>
     public class DataCache : ScriptableSingleton<DataCache>
     {
+
+        public Models.ModelData SelectedModelData { get { return selectedModelData; } set { selectedModelData = value; } }
+        private Models.ModelData selectedModelData = null;
+
         #region ImageDataList
 
         [SerializeField] private List<ImageDataStorage.ImageData> imageDataList = new();
@@ -139,6 +143,12 @@ namespace Scenario.Editor
         {
             get => EditorPrefs.GetString("SelectedModelId", "");
             set => EditorPrefs.SetString("SelectedModelId", value);
+        }
+
+        public string SelectedModelType
+        {
+            get => EditorPrefs.GetString("SelectedModelType", "");
+            set => EditorPrefs.SetString("SelectedModelType", value);
         }
 
         public int GetReservedSpaceCount()


### PR DESCRIPTION
Now according to modalities available on the webapp and SDXL / SD 1.5 tags, we have same options available on Unity plugin. 
Adding an array of translation of those modalities to manage api request and displaying interface in Unity.
Also renaming some variables.

![image](https://github.com/scenario-labs/Scenario-Unity/assets/30622829/d8306395-d871-4086-ae32-4959307d83b6)


![image](https://github.com/scenario-labs/Scenario-Unity/assets/30622829/173602ac-e5b1-4081-b0fa-f9ac38bad7c2)

- closes: #125 