### PR TITLE
fix: adding scheduler reception and displaying

### DIFF
--- a/package/Editor/Images/ImageDataClasses.cs
+++ b/package/Editor/Images/ImageDataClasses.cs
@@ -53,6 +53,7 @@ namespace Scenario.Editor
         public int width { get; set; }
         public bool hideResults { get; set; }
         public string type { get; set; }
+        public string scheduler { get; set; }
         public string prompt { get; set; }
         public string negativePrompt { get; set; }
         public int height { get; set; }

--- a/package/Editor/Images/Images.cs
+++ b/package/Editor/Images/Images.cs
@@ -93,7 +93,7 @@ namespace Scenario.Editor
                             Steps = inference.parameters.numInferenceSteps,
                             Size = new Vector2(inference.parameters.width,inference.parameters.height),
                             Guidance = inference.parameters.guidance,
-                            Scheduler = "Default", //TODO : change this to reflect the scheduler used for creating this image
+                            Scheduler = inference.parameters.scheduler,
                             Seed = image.seed,
                             CreatedAt = inference.createdAt,
                             modelId = inference.modelId

--- a/package/Editor/Images/Images.cs
+++ b/package/Editor/Images/Images.cs
@@ -23,11 +23,12 @@ namespace Scenario.Editor
         [MenuItem("Window/Scenario/Images")]
         public static void ShowWindow()
         {
-            if (!isVisible)
+            if (isVisible)
             {
-                lastPageToken = string.Empty;
-                imageDataList.Clear();
+                return;
             }
+            lastPageToken = string.Empty;
+            imageDataList.Clear();
             GetInferencesData();
 
             var images = (Images)GetWindow(typeof(Images));
@@ -41,7 +42,10 @@ namespace Scenario.Editor
 
         private void OnEnable()
         {
-            ShowWindow();
+            lastPageToken = string.Empty;
+            imageDataList.Clear();
+            GetInferencesData();
+            ImagesUI.Init();
         }
 
         private void OnDestroy()

--- a/package/Editor/Images/ImagesUI.cs
+++ b/package/Editor/Images/ImagesUI.cs
@@ -46,6 +46,14 @@ namespace Scenario.Editor
             InitializeButtons();
         }
 
+        /// <summary>
+        /// Re initialize the Image UI when it's already existing.
+        /// </summary>
+        public void Init()
+        {
+            InitializeButtons();
+        }
+
         #endregion
 
 
@@ -339,7 +347,14 @@ namespace Scenario.Editor
                 GUILayout.BeginHorizontal();
                 {
                     CustomStyle.Label($"Guidance: {currentImageData.Guidance}");
-                    CustomStyle.Label($"Scheduler: {currentImageData.Scheduler}");
+                    if (string.IsNullOrEmpty(currentImageData.Scheduler))
+                    {
+                        CustomStyle.Label($"Scheduler: Default");
+                    }
+                    else
+                    { 
+                        CustomStyle.Label($"Scheduler: {currentImageData.Scheduler}");
+                    }
                 }
                 GUILayout.EndHorizontal();
                 CustomStyle.Space(padding);

--- a/package/Editor/_Services/DataCache.cs
+++ b/package/Editor/_Services/DataCache.cs
@@ -63,7 +63,16 @@ namespace Scenario.Editor
             return imageDataList.GetRange(firstIndex, count);
         }
 
-        public void FillReservedSpaceForImageData(string inferenceId, string id, string url, DateTime createdAt, string _seed)
+        /// <summary>
+        /// After inference ending, get image generated and fill the space reserved to it.
+        /// </summary>
+        /// <param name="inferenceId"> Id of the Inference </param>
+        /// <param name="id"> Image Id </param>
+        /// <param name="url"> URL Image </param>
+        /// <param name="createdAt"> Date of creation </param>
+        /// <param name="_scheduler"> Scheduler of the generation</param>
+        /// <param name="_seed"> Seed of the generation </param>
+        public void FillReservedSpaceForImageData(string inferenceId, string id, string url, DateTime createdAt, string _scheduler, string _seed)
         {
             var itm = imageDataList.FirstOrDefault(x =>
             {
@@ -78,6 +87,7 @@ namespace Scenario.Editor
             itm.Id = id;
             itm.Url = url;
             itm.CreatedAt = createdAt;
+            itm.Scheduler = _scheduler;
             itm.Seed = _seed;
             CommonUtils.FetchTextureFromURL(itm.Url, texture =>
             {

--- a/package/Editor/_Services/PromptFetcher.cs
+++ b/package/Editor/_Services/PromptFetcher.cs
@@ -88,6 +88,7 @@ namespace Scenario.Editor
                             img.Id,
                             img.Url,
                             inferenceStatusRoot.inference.createdAt,
+                            inferenceStatusRoot.inference.parameters.scheduler,
                             img.Seed);
                     }
 
@@ -137,6 +138,7 @@ namespace Scenario.Editor
             public int width { get; set; }
             public int height { get; set; }
             public string type { get; set; }
+            public string scheduler { get; set; }
             public string image { get; set; }
             public string prompt { get; set; }
             public string mask { get; set; }


### PR DESCRIPTION
The selected scheduler is now displayed in the description image.

![image](https://github.com/scenario-labs/Scenario-Unity/assets/30622829/8ad4cd76-a191-49c3-bb51-cac938e37b69)

- closes: #136 