### PR TITLE
fix: using cdn extension on thumbnail models display

### DIFF
--- a/package/Editor/Models/Models.cs
+++ b/package/Editor/Models/Models.cs
@@ -57,6 +57,11 @@ namespace Scenario.Editor
         /// </summary>
         public static string privacyPublic = "public";
 
+        /// <summary>
+        /// Reference of compression url's extension to reduce memory storage and consumption
+        /// </summary>
+        internal static string cdnExtension = "&format=jpeg&quality=80&width=256";
+
         #endregion
 
         #region Private Fields
@@ -249,11 +254,11 @@ namespace Scenario.Editor
 
                 if (item.thumbnail != null && !string.IsNullOrEmpty(item.thumbnail.url))
                 {
-                    downloadUrl = item.thumbnail.url;
+                    downloadUrl = item.thumbnail.url + cdnExtension;
                 }
                 else if (item.trainingImages != null && item.trainingImages.Count > 0)
                 {
-                    downloadUrl = item.trainingImages[0].downloadUrl;
+                    downloadUrl = item.trainingImages[0].downloadUrl + cdnExtension;
                 }
 
                 if (string.IsNullOrEmpty(downloadUrl)) continue;
@@ -286,11 +291,11 @@ namespace Scenario.Editor
 
                 if (item.thumbnail != null && !string.IsNullOrEmpty(item.thumbnail.url))
                 {
-                    downloadUrl = item.thumbnail.url;
+                    downloadUrl = item.thumbnail.url + cdnExtension;
                 }
                 else if (item.trainingImages != null && item.trainingImages.Count > 0)
                 {
-                    downloadUrl = item.trainingImages[0].downloadUrl;
+                    downloadUrl = item.trainingImages[0].downloadUrl + cdnExtension;
                 }
 
                 if (string.IsNullOrEmpty(downloadUrl)) continue;
@@ -324,11 +329,11 @@ namespace Scenario.Editor
 
                 if (item.thumbnail != null && !string.IsNullOrEmpty(item.thumbnail.url))
                 {
-                    downloadUrl = item.thumbnail.url;
+                    downloadUrl = item.thumbnail.url + cdnExtension;
                 }
                 else if (item.trainingImages != null && item.trainingImages.Count > 0)
                 {
-                    downloadUrl = item.trainingImages[0].downloadUrl;
+                    downloadUrl = item.trainingImages[0].downloadUrl + cdnExtension;
                 }
 
                 if (string.IsNullOrEmpty(downloadUrl)) continue;


### PR DESCRIPTION
Use extension to download model image on 256x256
Divide memory consumption by 2.6

- closes: #168 